### PR TITLE
Rephrase Submodule Name Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,15 @@ Organized as git submodules from presenter's own repositories.
 Diverging ideas are welcome.
 
 ## Contributing
-Submodules should have presentation date in them in the format yyyy-mm-dd
-`git submodule add <git-repository-url>`
+
+You can clone this repo using:
+
+```sh
+git clone --recurse git@github.com:nairobilug/presentations.git
+```
+
+The submodule name should be the presentation's date followed by its title in this format -> `<yyyy-mm-dd>-<presentation-title-in-lisp-case>`:
+
+```sh
+git submodule add <git-repository-url> <name-of-submodule>
+```


### PR DESCRIPTION
Specifies that you should use lisp-case for the presentation titles when
naming the presentation Git submodules.

Also provides the command for cloning the project.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>