### PR TITLE
Reword Presentation Submodule Naming Format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ssh-tunneling-talk"]
-	path = 2018-03-03 ssh-tunneling
+	path = 2018-03-03-ssh-tunneling
 	url = git@github.com:kmwenja/ssh-tunneling-talk.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ Organized as git submodules from presenter's own repositories.
 Diverging ideas are welcome.
 
 ## Contributing
-Submodules should have presentation date in them in the format yyyy-mm-dd
+
+You can clone this repo using:
+
+```sh
+git clone --recurse git@github.com:nairobilug/presentations.git
 ```
-git submodule add <git-repository-url> yyyy-mm-dd\ presentation-name
+
+The submodule name should be the presentation's date followed by its title in this format -> `<yyyy-mm-dd>-<presentation-title-in-lisp-case>`:
+
+```sh
+git submodule add <git-repository-url> <name-of-submodule>
 ```


### PR DESCRIPTION
Specify the case to be used for the presentation title when naming the
git submodules for presentations.

Also specify which command to use when cloning project.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>